### PR TITLE
Upgrade data-of-loathing to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@react-router/node": "^7.12.0",
     "@react-router/serve": "^7.12.0",
     "clsx": "^2.1.1",
-    "data-of-loathing": "^2.6.2",
+    "data-of-loathing": "^3.2.2",
     "date-fns": "^4.1.0",
     "decimal.js": "^10.6.0",
     "dotenv": "^17.2.3",

--- a/scripts/etl.ts
+++ b/scripts/etl.ts
@@ -43,6 +43,8 @@ async function fetchItemData() {
     .where("name", "is", null)
     .execute();
 
+  if (unknown.length === 0) return;
+
   await dol.load();
 
   const data = await dol.query.find(Item, {

--- a/scripts/etl.ts
+++ b/scripts/etl.ts
@@ -1,6 +1,6 @@
 import { Decimal } from "decimal.js";
 import { format, sub, subDays } from "date-fns";
-import { createClient } from "data-of-loathing";
+import { createClient, Item } from "data-of-loathing";
 
 import { db } from "../app/db.server";
 import { query, type SaleResponse } from "./econ";
@@ -43,29 +43,11 @@ async function fetchItemData() {
     .where("name", "is", null)
     .execute();
 
-  const data = (
-    unknown.length > 20
-      ? ((
-          await dol.query({
-            allItems: { nodes: { id: true, name: true, image: true } },
-          })
-        ).allItems?.nodes ?? [])
-      : await Promise.all(
-          unknown.map(
-            async (item) =>
-              (
-                await dol.query({
-                  itemById: {
-                    id: true,
-                    name: true,
-                    image: true,
-                    __args: { id: item.itemId },
-                  },
-                })
-              ).itemById,
-          ),
-        )
-  ).filter((i) => i !== null);
+  await dol.load();
+
+  const data = await dol.query.find(Item, {
+    id: { $in: unknown.map((i) => i.itemId) },
+  });
 
   await db.transaction().execute(async (tx) => {
     for (const d of data) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -773,6 +773,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mikro-orm/core@npm:^7.0.14":
+  version: 7.0.15
+  resolution: "@mikro-orm/core@npm:7.0.15"
+  peerDependencies:
+    dataloader: 2.2.3
+  peerDependenciesMeta:
+    dataloader:
+      optional: true
+  checksum: 10c0/9dd237c086ef9603f336156557181dcaaa4a74f865b5795dce86f14655832d936186dee011fbb38b7086477e6f6cb13be25cd3bac9c2c62fb80cf306028f6207
+  languageName: node
+  linkType: hard
+
+"@mikro-orm/sql@npm:^7.0.14":
+  version: 7.0.15
+  resolution: "@mikro-orm/sql@npm:7.0.15"
+  dependencies:
+    kysely: "npm:0.28.17"
+  peerDependencies:
+    "@mikro-orm/core": 7.0.15
+  checksum: 10c0/1d7aacccd2da0d80e954367b427253f47dc4a23f4ff4fed14fc69f05a66c0ada97e29a0ed4aab58a4e073684f461eab8600fbee485a60264a73a576360ccac1e
+  languageName: node
+  linkType: hard
+
 "@mjackson/node-fetch-server@npm:^0.2.0":
   version: 0.2.0
   resolution: "@mjackson/node-fetch-server@npm:0.2.0"
@@ -1234,6 +1257,13 @@ __metadata:
   version: 4.53.2
   resolution: "@rollup/rollup-win32-x64-msvc@npm:4.53.2"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@sqlite.org/sqlite-wasm@npm:~3.51.2-build9":
+  version: 3.51.2-build9
+  resolution: "@sqlite.org/sqlite-wasm@npm:3.51.2-build9"
+  checksum: 10c0/2b9c4d3df7b2cf84c1b311ac276c19692d8ccad4a4b34a1a739e1eb3b8938c6be4e64a98d51b7ea6e9ad5000a912d4ed0c25eec146f7eb468fa343b7ce491a08
   languageName: node
   linkType: hard
 
@@ -2061,10 +2091,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"data-of-loathing@npm:^2.6.2":
-  version: 2.6.2
-  resolution: "data-of-loathing@npm:2.6.2"
-  checksum: 10c0/160be95e0886d797ddde79d25285cd3a09861097ac9131b7ceb5f2119648ba31d5d0ed1322e31a607140e9b610580095b95b4b6f72057790e12b1abd67ecbc17
+"data-of-loathing@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "data-of-loathing@npm:3.2.2"
+  dependencies:
+    "@mikro-orm/core": "npm:^7.0.14"
+    "@mikro-orm/sql": "npm:^7.0.14"
+    "@sqlite.org/sqlite-wasm": "npm:~3.51.2-build9"
+    env-paths: "npm:^4.0.0"
+    kysely: "npm:^0.28.17"
+  peerDependencies:
+    vite: ">=5.0.0"
+    vite-plugin-node-polyfills: ^0.26.0
+  peerDependenciesMeta:
+    vite:
+      optional: true
+    vite-plugin-node-polyfills:
+      optional: true
+  checksum: 10c0/c2238b96ef4be0e8c3384ca205ba80cb9b54e2c8e92d09c6d85f5fba0de316bfff642e899fbac874869ff32f50cac0b74bccbfeaec0d542f740f4c16384c832e
   languageName: node
   linkType: hard
 
@@ -2246,6 +2290,15 @@ __metadata:
   version: 3.0.0
   resolution: "env-paths@npm:3.0.0"
   checksum: 10c0/76dec878cee47f841103bacd7fae03283af16f0702dad65102ef0a556f310b98a377885e0f32943831eb08b5ab37842a323d02529f3dfd5d0a40ca71b01b435f
+  languageName: node
+  linkType: hard
+
+"env-paths@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "env-paths@npm:4.0.0"
+  dependencies:
+    is-safe-filename: "npm:^0.1.0"
+  checksum: 10c0/13ee7fa4047786ca28f1fbf2239606f8a53304bdf71bfc426e95f806e429060181205316f2c45b4ac560e81c854ded5a45fd9dc3105414c01d504b3469a1294b
   languageName: node
   linkType: hard
 
@@ -2992,6 +3045,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-safe-filename@npm:^0.1.0":
+  version: 0.1.1
+  resolution: "is-safe-filename@npm:0.1.1"
+  checksum: 10c0/45c35d2253b96348e2c26590e14feed51d1e6b72aaa567930ccb34e68c0eef00ebcf3b7e01b46bf45e578a27355cd8f5bc12f7d6d79a34d33dc93d4560c0f6b6
+  languageName: node
+  linkType: hard
+
 "is-what@npm:^3.14.1":
   version: 3.14.1
   resolution: "is-what@npm:3.14.1"
@@ -3102,6 +3162,13 @@ __metadata:
   bin:
     kysely: dist/bin.mjs
   checksum: 10c0/7588a1663c90e8c7b5943b19a7c91e78e4e83d7d1ab9f314af44e2734172cbb5e772a1807d8599f3ae29ca2172db5c4c38d9ef4d5a67280db6c7cceefdd2e7cc
+  languageName: node
+  linkType: hard
+
+"kysely@npm:0.28.17, kysely@npm:^0.28.17":
+  version: 0.28.17
+  resolution: "kysely@npm:0.28.17"
+  checksum: 10c0/70573292d8d60a1e29be9b432c1b25fe21d4806ecd5e9859b5ba8d2af799769878f4b3d91731ffe3e03744c7291476fe843640d31741f3637e20c3c49afea3c5
   languageName: node
   linkType: hard
 
@@ -3944,7 +4011,7 @@ __metadata:
     "@types/react-dom": "npm:^19.2.3"
     "@types/react-is": "npm:^19.2.0"
     clsx: "npm:^2.1.1"
-    data-of-loathing: "npm:^2.6.2"
+    data-of-loathing: "npm:^3.2.2"
     date-fns: "npm:^4.1.0"
     decimal.js: "npm:^10.6.0"
     dotenv: "npm:^17.2.3"


### PR DESCRIPTION
## Summary

- Bumps `data-of-loathing` from `^2.6.2` to `^3.2.2`
- v3 ships an embedded SQLite database queried locally via MikroORM, replacing the v2 GenQL/GraphQL client against the PostGraphile API
- `fetchItemData` now calls `await dol.load()` to initialise the database, then uses `dol.query.find(Item, { id: { $in: [...] } })` — the old two-branch logic (fetch-all vs. one-by-one) collapses to a single filtered query

## Test plan

- [ ] Run `yarn etl` against a dev database and confirm items with `name IS NULL` get populated
- [ ] Run `yarn typecheck` passes