### PR TITLE
Add monthly and all-time price history views

### DIFF
--- a/app/components/Chart.tsx
+++ b/app/components/Chart.tsx
@@ -12,10 +12,13 @@ import {
 import { useMemo } from "react";
 import {
   shortDateFormatter,
+  monthYearFormatter,
+  shortDateYearFormatter,
   numberFormatter,
   shortNumberFormatter,
   splitDecimal,
 } from "~/utils";
+import type { Period } from "~/components/PeriodToggle";
 
 const COLORS = [
   "#003a7d",
@@ -39,9 +42,24 @@ type ItemData = {
 
 type Props = {
   item: ItemData;
+  period?: Period;
 };
 
-export function Chart({ item }: Props) {
+const tickFormatters: Record<Period, Intl.DateTimeFormat> = {
+  daily: shortDateFormatter,
+  weekly: shortDateFormatter,
+  monthly: monthYearFormatter,
+  all: shortDateYearFormatter,
+};
+
+const tooltipDateOptions: Record<Period, Intl.DateTimeFormatOptions> = {
+  daily: { weekday: "short", month: "short", day: "numeric" },
+  weekly: { weekday: "short", month: "short", day: "numeric" },
+  monthly: { month: "short", year: "numeric" },
+  all: { month: "short", day: "numeric", year: "numeric" },
+};
+
+export function Chart({ item, period = "daily" }: Props) {
   const { data, series } = useMemo(() => {
     const series = [
       {
@@ -85,7 +103,7 @@ export function Chart({ item }: Props) {
             (dataMax: number) => dataMax + 24 * 60 * 60 * 1000,
           ]}
           tickFormatter={(iso: string) =>
-            shortDateFormatter.format(new Date(iso))
+            tickFormatters[period].format(new Date(iso))
           }
         />
         <YAxis
@@ -102,12 +120,11 @@ export function Chart({ item }: Props) {
           label={{ value: `Price`, angle: 90, position: "insideRight" }}
         />
         <Tooltip<number, `${string} Price` | `${string} Volume`>
-          labelFormatter={(iso: string) =>
-            new Date(iso).toLocaleDateString(undefined, {
-              weekday: "short",
-              month: "short",
-              day: "numeric",
-            })
+          labelFormatter={(timestamp) =>
+            new Date(timestamp as number).toLocaleDateString(
+              undefined,
+              tooltipDateOptions[period],
+            )
           }
           formatter={(value, name) => [
             value && numberFormatter.format(value),

--- a/app/components/PeriodToggle.tsx
+++ b/app/components/PeriodToggle.tsx
@@ -2,7 +2,9 @@ import { z } from "zod";
 
 import styles from "./PeriodToggle.module.css";
 
-export const periodSchema = z.enum(["daily", "weekly", "monthly", "all"]);
+export const periodSchema = z
+  .enum(["daily", "weekly", "monthly", "all"])
+  .catch("daily");
 export type Period = z.infer<typeof periodSchema>;
 
 type Props = {

--- a/app/components/PeriodToggle.tsx
+++ b/app/components/PeriodToggle.tsx
@@ -1,6 +1,9 @@
+import { z } from "zod";
+
 import styles from "./PeriodToggle.module.css";
 
-export type Period = "daily" | "weekly" | "monthly" | "all";
+export const periodSchema = z.enum(["daily", "weekly", "monthly", "all"]);
+export type Period = z.infer<typeof periodSchema>;
 
 type Props = {
   value: Period;

--- a/app/components/PeriodToggle.tsx
+++ b/app/components/PeriodToggle.tsx
@@ -1,6 +1,6 @@
 import styles from "./PeriodToggle.module.css";
 
-export type Period = "daily" | "weekly";
+export type Period = "daily" | "weekly" | "monthly" | "all";
 
 type Props = {
   value: Period;
@@ -10,6 +10,8 @@ type Props = {
 const periods: { value: Period; label: string; title: string }[] = [
   { value: "daily", label: "D", title: "Daily for the past two weeks" },
   { value: "weekly", label: "W", title: "Weekly for the past three months" },
+  { value: "monthly", label: "M", title: "Monthly for the past year" },
+  { value: "all", label: "A", title: "Weekly for all time" },
 ];
 
 export function PeriodToggle({ value, onChange }: Props) {

--- a/app/db.server.ts
+++ b/app/db.server.ts
@@ -3,6 +3,7 @@ import { Decimal } from "decimal.js";
 import { Pool, types } from "pg";
 import { Kysely, PostgresDialect, sql } from "kysely";
 import { DecimalPlugin } from "./DecimalPlugin.js";
+import type { Period } from "./components/PeriodToggle.js";
 
 // Convert NUMERIC values from PostgreSQL to Decimal.js instances when reading
 types.setTypeParser(types.builtins.NUMERIC, (value) => new Decimal(value));
@@ -64,12 +65,16 @@ export async function getSpendLeaderboard(since: Date) {
   }));
 }
 
-export async function getSalesHistory(
-  itemId: number,
-  mode: "daily" | "weekly" = "daily",
-) {
-  const truncUnit = sql.raw(mode === "weekly" ? "'week'" : "'day'");
-  const interval = sql.raw(mode === "weekly" ? "'3 months'" : "'14 days'");
+const historyModes = {
+  daily: { trunc: "'day'", interval: "'14 days'" },
+  weekly: { trunc: "'week'", interval: "'3 months'" },
+  monthly: { trunc: "'month'", interval: "'1 year'" },
+  all: { trunc: "'week'", interval: null },
+} as const;
+
+export async function getSalesHistory(itemId: number, mode: Period = "daily") {
+  const { trunc, interval } = historyModes[mode];
+  const truncUnit = sql.raw(trunc);
 
   return await db
     .selectFrom("Sale")
@@ -80,7 +85,13 @@ export async function getSalesHistory(
       sql<Decimal>`ROUND(AVG("unitPrice"), 2)`.as("price"),
     ])
     .where("itemId", "=", itemId)
-    .where("Sale.date", ">=", sql<Date>`NOW() - INTERVAL ${interval}`)
+    .$if(interval !== null, (qb) =>
+      qb.where(
+        "Sale.date",
+        ">=",
+        sql<Date>`NOW() - INTERVAL ${sql.raw(interval!)}`,
+      ),
+    )
     .groupBy(["itemId", sql<Date>`date_trunc(${truncUnit}, "date")::date`])
     .orderBy("date", "asc")
     .execute();
@@ -89,7 +100,7 @@ export async function getSalesHistory(
 export async function getItemWithSales(
   itemId: number,
   numberOfSales = 20,
-  historyMode: "daily" | "weekly" = "daily",
+  historyMode: Period = "daily",
 ) {
   const item = await db
     .selectFrom("Item")

--- a/app/routes/api.$itemid.tsx
+++ b/app/routes/api.$itemid.tsx
@@ -6,9 +6,7 @@ import { periodSchema } from "~/components/PeriodToggle";
 
 export async function loader({ params, request }: Route.LoaderArgs) {
   const url = new URL(request.url);
-  const historyMode = periodSchema
-    .catch("daily")
-    .parse(url.searchParams.get("history"));
+  const historyMode = periodSchema.parse(url.searchParams.get("history"));
 
   const itemIds = params["itemid"]!.split(",")
     .map(Number)

--- a/app/routes/api.$itemid.tsx
+++ b/app/routes/api.$itemid.tsx
@@ -2,11 +2,15 @@ import { data } from "react-router";
 import type { Route } from "./+types/api.$itemid.js";
 import { getItemWithSales } from "~/db.server.js";
 import { serializeDecimals } from "~/hooks/useLoaderDataWithDecimals";
+import type { Period } from "~/components/PeriodToggle";
 
 export async function loader({ params, request }: Route.LoaderArgs) {
   const url = new URL(request.url);
-  const historyMode =
-    url.searchParams.get("history") === "weekly" ? "weekly" : "daily";
+  const param = url.searchParams.get("history");
+  const historyMode: Period =
+    param === "weekly" || param === "monthly" || param === "all"
+      ? param
+      : "daily";
 
   const itemIds = params["itemid"]!.split(",")
     .map(Number)

--- a/app/routes/api.$itemid.tsx
+++ b/app/routes/api.$itemid.tsx
@@ -2,15 +2,13 @@ import { data } from "react-router";
 import type { Route } from "./+types/api.$itemid.js";
 import { getItemWithSales } from "~/db.server.js";
 import { serializeDecimals } from "~/hooks/useLoaderDataWithDecimals";
-import type { Period } from "~/components/PeriodToggle";
+import { periodSchema } from "~/components/PeriodToggle";
 
 export async function loader({ params, request }: Route.LoaderArgs) {
   const url = new URL(request.url);
-  const param = url.searchParams.get("history");
-  const historyMode: Period =
-    param === "weekly" || param === "monthly" || param === "all"
-      ? param
-      : "daily";
+  const historyMode = periodSchema
+    .catch("daily")
+    .parse(url.searchParams.get("history"));
 
   const itemIds = params["itemid"]!.split(",")
     .map(Number)

--- a/app/routes/item.$itemid.tsx
+++ b/app/routes/item.$itemid.tsx
@@ -76,7 +76,7 @@ export default function ItemPage() {
       <div className={styles.chartHeader}>
         <PeriodToggle value={period} onChange={handlePeriodChange} />
       </div>
-      <Chart item={chartItem} />
+      <Chart item={chartItem} period={period} />
       <RecentSales
         item={{ itemId: item.itemId, name: item.name }}
         sales={item.sales}

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -52,6 +52,17 @@ export const shortDateFormatter = new Intl.DateTimeFormat(undefined, {
   day: "numeric",
 });
 
+export const monthYearFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  year: "numeric",
+});
+
+export const shortDateYearFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  year: "2-digit",
+});
+
 export const dateFormatter = new Intl.DateTimeFormat(undefined, {
   dateStyle: "short",
   timeStyle: "short",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react-is": "^19.2.3",
     "react-router": "^7.12.0",
     "react-select": "^5.10.2",
-    "recharts": "^3.6.0"
+    "recharts": "^3.6.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@react-router/dev": "^7.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3964,6 +3964,7 @@ __metadata:
     vite: "npm:^7.3.1"
     vite-tsconfig-paths: "npm:^6.0.4"
     vitest: "npm:^4.0.17"
+    zod: "npm:^4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -5195,5 +5196,12 @@ __metadata:
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: 10c0/5c28b9eb7adc46544f28d9a8d20c5b3cb1215a886609a2fd41f51628d8aaa5878ccd628b755dbcd29f6bb4921bd04ffbc6dcc370689bb96e594e2f9813d2605f
+  languageName: node
+  linkType: hard
+
+"zod@npm:^4.4.3":
+  version: 4.4.3
+  resolution: "zod@npm:4.4.3"
+  checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3
   languageName: node
   linkType: hard


### PR DESCRIPTION
Adds two new tabs to the item price history chart alongside the existing D (daily, 14 days) and W (weekly, 3 months):

- **M** — monthly buckets over the past year
- **A** — weekly buckets over all time (data goes back to 2025-10-24, when raw sale lines were first stored)

Changes:

- `PeriodToggle` — `Period` type extended to include `monthly` and `all`, plus the two new buttons
- `getSalesHistory` — mode config moved to a `historyModes` map (trunc unit + lookback interval); `all` has no lower bound, applied conditionally via `$if`
- `api.$itemid` — validates the `?history=` param against all four values
- `Chart` — new `period` prop drives tick/tooltip date formatting so month/all-time views include the year
- Fixes a pre-existing `tsc` error on the chart tooltip `labelFormatter` (the label is the numeric timestamp, not an ISO string) — `yarn typecheck` is now green