### PR TITLE
Key recent sales by sale id to fix stale rows when switching items

### DIFF
--- a/app/components/RecentSales.tsx
+++ b/app/components/RecentSales.tsx
@@ -5,7 +5,7 @@ import type { Item } from "./ItemSelect";
 
 type Props = {
   item: Item | null;
-  sales: { date: Date; unitPrice: Decimal; quantity: number }[];
+  sales: { id: number; date: Date; unitPrice: Decimal; quantity: number }[];
 };
 
 export function RecentSales({ item, sales }: Props) {
@@ -17,7 +17,7 @@ export function RecentSales({ item, sales }: Props) {
       <ol className={styles.list}>
         {sales.map((sale) => (
           <li
-            key={`${item.itemId}-${sale.date.toISOString()}-${sale.unitPrice}-${sale.quantity}`}
+            key={sale.id}
             className={styles.item}
           >
             <span className={styles.badge}>

--- a/app/db.server.ts
+++ b/app/db.server.ts
@@ -113,6 +113,7 @@ export async function getItemWithSales(
   const sales = await db
     .selectFrom("Sale")
     .select([
+      "Sale.id as id",
       "Sale.date as date",
       "Sale.unitPrice as unitPrice",
       "Sale.quantity as quantity",


### PR DESCRIPTION
The recent sales list keyed rows by itemId-date-unitPrice-quantity, which isn't unique in prod data, causing React to leave stale rows from the previous item after client-side navigation — key by the Sale serial id instead.